### PR TITLE
Feature/backend refresh token

### DIFF
--- a/Backend.Tests/Controllers/CommentControllerTests.cs
+++ b/Backend.Tests/Controllers/CommentControllerTests.cs
@@ -16,7 +16,7 @@ public class CommentControllerTests
         var currentUserId = Guid.NewGuid();
         var task = CreateTask(assignedUserId: Guid.NewGuid());
         var commentService = new FakeCommentService();
-        var controller = CreateController(task, commentService, currentUserId, "User");
+        var controller = CreateController(task, commentService, currentUserId, "User", grantAccess: false);
 
         var result = await controller.GetComments(task.Id);
 
@@ -92,9 +92,9 @@ public class CommentControllerTests
         Assert.Equal(currentUserId, commentService.LastUpdateUserId);
     }
 
-    private static CommentController CreateController(TaskItem task, FakeCommentService commentService, Guid currentUserId, string role)
+    private static CommentController CreateController(TaskItem task, FakeCommentService commentService, Guid currentUserId, string role, bool grantAccess = true)
     {
-        var controller = new CommentController(commentService, new FakeTaskService(task));
+        var controller = new CommentController(commentService, new FakeTaskService(task), new FakeProjectService(grantAccess));
 
         controller.ControllerContext = new ControllerContext
         {
@@ -203,5 +203,33 @@ public class CommentControllerTests
         {
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class FakeProjectService : IProjectService
+    {
+        private readonly bool _grantAccess;
+
+        public FakeProjectService(bool grantAccess = true)
+        {
+            _grantAccess = grantAccess;
+        }
+
+        public Task<List<Project>> GetAll() => throw new NotImplementedException();
+        public Task<List<Project>> GetAccessibleProjects(Guid userId, bool elevatedAccess) => throw new NotImplementedException();
+        public Task<Project> Create(ProjectDto dto, Guid creatorUserId) => throw new NotImplementedException();
+        public Task<Project?> GetById(Guid id) => throw new NotImplementedException();
+        public Task<Project?> Update(Guid id, ProjectDto dto) => throw new NotImplementedException();
+        public Task<bool> Delete(Guid id) => throw new NotImplementedException();
+        public Task<bool> ProjectExists(Guid id) => Task.FromResult(true);
+        public Task<bool> HasReadAccess(Guid projectId, Guid userId, bool elevatedAccess) => Task.FromResult(_grantAccess);
+        public Task<bool> HasWriteAccess(Guid projectId, Guid userId, bool elevatedAccess) => Task.FromResult(_grantAccess);
+        public Task<bool> HasManageAccess(Guid projectId, Guid userId, bool elevatedAccess) => throw new NotImplementedException();
+        public Task<List<ProjectMemberDto>> GetMembers(Guid projectId) => throw new NotImplementedException();
+        public Task<ProjectMemberDto> AddMember(Guid projectId, AddProjectMemberDto dto, Guid actorUserId) => throw new NotImplementedException();
+        public Task<List<ProjectInvitationDto>> GetInvitations(Guid projectId) => throw new NotImplementedException();
+        public Task<ProjectInvitationDto> CreateInvitation(Guid projectId, CreateProjectInvitationDto dto, Guid actorUserId) => throw new NotImplementedException();
+        public Task<List<ProjectInvitationLookupDto>> GetInvitationsForUser(Guid userId) => throw new NotImplementedException();
+        public Task<ProjectInvitationLookupDto> GetInvitationById(Guid invitationId) => throw new NotImplementedException();
+        public Task<AcceptProjectInvitationResultDto> AcceptInvitation(Guid invitationId, Guid actorUserId) => throw new NotImplementedException();
     }
 }

--- a/Backend.Tests/Services/AuthServiceTests.cs
+++ b/Backend.Tests/Services/AuthServiceTests.cs
@@ -76,6 +76,155 @@ public class AuthServiceTests
         Assert.Equal("Email already registered", duplicateResult.Message);
     }
 
+    [Fact]
+    public async Task Register_ReturnsRefreshToken()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+
+        var result = await service.Register(new RegisterDto
+        {
+            Name = "Test User",
+            Email = "test@example.com",
+            Password = "Password123!"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(string.IsNullOrWhiteSpace(result.Token));
+        Assert.False(string.IsNullOrWhiteSpace(result.RefreshToken));
+        Assert.NotNull(result.RefreshTokenExpiry);
+        Assert.True(result.RefreshTokenExpiry > DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task Login_ReturnsRefreshToken()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+
+        await service.Register(new RegisterDto
+        {
+            Name = "Test User",
+            Email = "test@example.com",
+            Password = "Password123!"
+        });
+
+        var result = await service.Login(new LoginDto
+        {
+            Email = "test@example.com",
+            Password = "Password123!"
+        });
+
+        Assert.True(result.Success);
+        Assert.False(string.IsNullOrWhiteSpace(result.Token));
+        Assert.False(string.IsNullOrWhiteSpace(result.RefreshToken));
+        Assert.NotNull(result.RefreshTokenExpiry);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ReturnsNewAccessAndRefreshToken()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+
+        var loginResult = await service.Login(await RegisterAndLogin(service));
+
+        var refreshResult = await service.RefreshTokenAsync(loginResult.RefreshToken!);
+
+        Assert.True(refreshResult.Success);
+        Assert.False(string.IsNullOrWhiteSpace(refreshResult.Token));
+        Assert.False(string.IsNullOrWhiteSpace(refreshResult.RefreshToken));
+        Assert.NotEqual(loginResult.RefreshToken, refreshResult.RefreshToken);
+        Assert.NotNull(refreshResult.User);
+    }
+
+    [Fact]
+    public async Task RefreshToken_RevokesOldToken()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+
+        var loginResult = await service.Login(await RegisterAndLogin(service));
+        var oldRefreshToken = loginResult.RefreshToken!;
+
+        // First refresh should succeed
+        var refreshResult = await service.RefreshTokenAsync(oldRefreshToken);
+        Assert.True(refreshResult.Success);
+
+        // Reusing the old token should fail (token reuse detection)
+        var reuseResult = await service.RefreshTokenAsync(oldRefreshToken);
+        Assert.False(reuseResult.Success);
+    }
+
+    [Fact]
+    public async Task RefreshToken_RejectsInvalidToken()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+
+        var result = await service.RefreshTokenAsync("totally-invalid-token");
+
+        Assert.False(result.Success);
+        Assert.Equal("Invalid refresh token", result.Message);
+    }
+
+    [Fact]
+    public async Task Logout_RevokesRefreshToken()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+
+        var loginResult = await service.Login(await RegisterAndLogin(service));
+
+        await service.LogoutAsync(loginResult.RefreshToken!);
+
+        // Trying to use the revoked token should fail
+        var refreshResult = await service.RefreshTokenAsync(loginResult.RefreshToken!);
+        Assert.False(refreshResult.Success);
+    }
+
+    [Fact]
+    public async Task RevokeAll_RevokesAllUserTokens()
+    {
+        await using var context = CreateContext();
+        var service = CreateService(context);
+
+        var dto = await RegisterAndLogin(service);
+
+        // Login multiple times to create multiple refresh tokens
+        var login1 = await service.Login(dto);
+        var login2 = await service.Login(dto);
+
+        // Get the user ID
+        var userId = login1.User!.Id;
+
+        // Revoke all
+        await service.RevokeAllTokensAsync(userId);
+
+        // Both tokens should be revoked
+        var refresh1 = await service.RefreshTokenAsync(login1.RefreshToken!);
+        var refresh2 = await service.RefreshTokenAsync(login2.RefreshToken!);
+
+        Assert.False(refresh1.Success);
+        Assert.False(refresh2.Success);
+    }
+
+    private static async Task<LoginDto> RegisterAndLogin(AuthService service)
+    {
+        await service.Register(new RegisterDto
+        {
+            Name = "Test User",
+            Email = "test@example.com",
+            Password = "Password123!"
+        });
+
+        return new LoginDto
+        {
+            Email = "test@example.com",
+            Password = "Password123!"
+        };
+    }
+
     private static AppDbContext CreateContext()
     {
         var options = new DbContextOptionsBuilder<AppDbContext>()
@@ -92,7 +241,8 @@ public class AuthServiceTests
             Secret = "test-secret-key-that-is-long-enough-for-hmac",
             Issuer = "TestIssuer",
             Audience = "TestAudience",
-            ExpirationHours = 24
+            AccessTokenExpirationMinutes = 15,
+            RefreshTokenExpirationDays = 7
         });
 
         return new AuthService(context, jwtOptions, NullLogger<AuthService>.Instance);

--- a/Backend/Controllers/AuthController.cs
+++ b/Backend/Controllers/AuthController.cs
@@ -4,12 +4,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
+using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/auth")]
-[AllowAnonymous]
-public class AuthController : ControllerBase
+public class AuthController : BaseApiController
 {
     private readonly IAuthService _authService;
 
@@ -19,6 +19,7 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("register")]
+    [AllowAnonymous]
     public async Task<IActionResult> Register([FromBody] RegisterDto dto)
     {
         var result = await _authService.Register(dto);
@@ -32,6 +33,7 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("login")]
+    [AllowAnonymous]
     public async Task<IActionResult> Login([FromBody] LoginDto dto)
     {
         var result = await _authService.Login(dto);
@@ -42,5 +44,36 @@ public class AuthController : ControllerBase
         }
 
         return Ok(ApiResponseDto<AuthResponseDto>.Ok(result, result.Message));
+    }
+
+    [HttpPost("refresh")]
+    [AllowAnonymous]
+    public async Task<IActionResult> RefreshToken([FromBody] RefreshTokenDto dto)
+    {
+        var result = await _authService.RefreshTokenAsync(dto.RefreshToken);
+
+        if (!result.Success)
+        {
+            return Unauthorized(ApiResponseDto<object>.Fail(result.Message));
+        }
+
+        return Ok(ApiResponseDto<AuthResponseDto>.Ok(result, result.Message));
+    }
+
+    [HttpPost("logout")]
+    [Authorize]
+    public async Task<IActionResult> Logout([FromBody] RefreshTokenDto dto)
+    {
+        await _authService.LogoutAsync(dto.RefreshToken);
+        return Ok(ApiResponseDto<object>.Ok(null, "Logged out successfully"));
+    }
+
+    [HttpPost("revoke-all")]
+    [Authorize]
+    public async Task<IActionResult> RevokeAll()
+    {
+        var userId = GetCurrentUserId();
+        await _authService.RevokeAllTokensAsync(userId);
+        return Ok(ApiResponseDto<object>.Ok(null, "All sessions have been revoked"));
     }
 }

--- a/Backend/Controllers/BaseApiController.cs
+++ b/Backend/Controllers/BaseApiController.cs
@@ -1,0 +1,36 @@
+namespace Backend.Controllers;
+
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+/// <summary>
+/// Base controller providing common helper methods shared across all API controllers.
+/// Eliminates duplication of GetCurrentUserId() and HasElevatedAccess() across the codebase.
+/// </summary>
+public abstract class BaseApiController : ControllerBase
+{
+    /// <summary>
+    /// Extracts the current authenticated user's ID from the JWT claims.
+    /// </summary>
+    protected Guid GetCurrentUserId()
+    {
+        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+        if (!Guid.TryParse(userIdClaim, out var userId))
+            throw new UnauthorizedAccessException("Invalid user context");
+
+        return userId;
+    }
+
+    /// <summary>
+    /// Checks whether the current user has elevated access (Admin or Manager roles).
+    /// Set <paramref name="includeManager"/> to false for Admin-only checks.
+    /// </summary>
+    protected bool HasElevatedAccess(bool includeManager = true)
+    {
+        if (User.IsInRole("Admin"))
+            return true;
+
+        return includeManager && User.IsInRole("Manager");
+    }
+}

--- a/Backend/Controllers/ChecklistController.cs
+++ b/Backend/Controllers/ChecklistController.cs
@@ -4,23 +4,19 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
-using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/tasks/{taskId}/checklist")]
 [Authorize]
-public class ChecklistController : ControllerBase
+public class ChecklistController : TaskAccessController
 {
     private readonly IChecklistService _service;
-    private readonly ITaskService _taskService;
-    private readonly IProjectService _projectService;
 
     public ChecklistController(IChecklistService service, ITaskService taskService, IProjectService projectService)
+        : base(taskService, projectService)
     {
         _service = service;
-        _taskService = taskService;
-        _projectService = projectService;
     }
 
     /// <summary>
@@ -154,52 +150,5 @@ public class ChecklistController : ControllerBase
         {
             return NotFound(ApiResponseDto<object>.Fail(ex.Message));
         }
-    }
-
-    private bool HasElevatedAccess()
-    {
-        return User.IsInRole("Admin") || User.IsInRole("Manager");
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
-    }
-
-    private async Task<Backend.Models.Entities.TaskItem> EnsureTaskReadAccessAsync(Guid taskId)
-    {
-        var task = await _taskService.GetById(taskId);
-
-        if (HasElevatedAccess())
-            return task;
-
-        var currentUserId = GetCurrentUserId();
-        var canRead = await _projectService.HasReadAccess(task.ProjectId, currentUserId, elevatedAccess: false);
-
-        if (!canRead)
-            throw new UnauthorizedAccessException("You do not have read access to this task");
-
-        return task;
-    }
-
-    private async Task<Backend.Models.Entities.TaskItem> EnsureTaskWriteAccessAsync(Guid taskId)
-    {
-        var task = await _taskService.GetById(taskId);
-
-        if (HasElevatedAccess())
-            return task;
-
-        var currentUserId = GetCurrentUserId();
-        var canWrite = await _projectService.HasWriteAccess(task.ProjectId, currentUserId, elevatedAccess: false);
-
-        if (!canWrite)
-            throw new UnauthorizedAccessException("You do not have write access to this task");
-
-        return task;
     }
 }

--- a/Backend/Controllers/CommentController.cs
+++ b/Backend/Controllers/CommentController.cs
@@ -5,29 +5,19 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
-using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/tasks/{taskId}/comments")]
 [Authorize]
-public class CommentController : ControllerBase
+public class CommentController : TaskAccessController
 {
     private readonly ICommentService _service;
-    private readonly ITaskService _taskService;
-    private readonly IProjectService? _projectService;
 
-    public CommentController(ICommentService service, ITaskService taskService)
-        : this(service, taskService, null)
-    {
-    }
-
-    [ActivatorUtilitiesConstructor]
-    public CommentController(ICommentService service, ITaskService taskService, IProjectService? projectService)
+    public CommentController(ICommentService service, ITaskService taskService, IProjectService projectService)
+        : base(taskService, projectService)
     {
         _service = service;
-        _taskService = taskService;
-        _projectService = projectService;
     }
 
     /// <summary>
@@ -129,70 +119,5 @@ public class CommentController : ControllerBase
         {
             return Forbid();
         }
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
-    }
-
-    private bool HasElevatedAccess()
-    {
-        return User.IsInRole("Admin") || User.IsInRole("Manager");
-    }
-
-    private async Task<Backend.Models.Entities.TaskItem> EnsureTaskReadAccessAsync(Guid taskId)
-    {
-        var task = await _taskService.GetById(taskId);
-
-        if (HasElevatedAccess())
-            return task;
-
-        var currentUserId = GetCurrentUserId();
-
-        if (_projectService != null)
-        {
-            var canRead = await _projectService.HasReadAccess(task.ProjectId, currentUserId, elevatedAccess: false);
-
-            if (!canRead)
-                throw new UnauthorizedAccessException("You do not have read access to this task");
-
-            return task;
-        }
-
-        if (task.AssignedUserId != currentUserId)
-            throw new UnauthorizedAccessException("You can only access your own tasks");
-
-        return task;
-    }
-
-    private async Task<Backend.Models.Entities.TaskItem> EnsureTaskWriteAccessAsync(Guid taskId)
-    {
-        var task = await _taskService.GetById(taskId);
-
-        if (HasElevatedAccess())
-            return task;
-
-        var currentUserId = GetCurrentUserId();
-
-        if (_projectService != null)
-        {
-            var canWrite = await _projectService.HasWriteAccess(task.ProjectId, currentUserId, elevatedAccess: false);
-
-            if (!canWrite)
-                throw new UnauthorizedAccessException("You do not have write access to this task");
-
-            return task;
-        }
-
-        if (task.AssignedUserId != currentUserId)
-            throw new UnauthorizedAccessException("You can only access your own tasks");
-
-        return task;
     }
 }

--- a/Backend/Controllers/DashboardController.cs
+++ b/Backend/Controllers/DashboardController.cs
@@ -8,7 +8,7 @@ using Backend.Services.Interfaces;
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/dashboard")]
 [Authorize]
-public class DashboardController : ControllerBase
+public class DashboardController : BaseApiController
 {
     private readonly IDashboardService _service;
 

--- a/Backend/Controllers/LabelController.cs
+++ b/Backend/Controllers/LabelController.cs
@@ -4,13 +4,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
-using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/projects/{projectId}/labels")]
 [Authorize]
-public class LabelController : ControllerBase
+public class LabelController : BaseApiController
 {
     private readonly ILabelService _labelService;
     private readonly IProjectService _projectService;
@@ -255,21 +254,6 @@ public class LabelController : ControllerBase
         {
             return StatusCode(500, ApiResponseDto<object>.Fail($"Internal server error: {ex.Message}"));
         }
-    }
-
-    private bool HasElevatedAccess()
-    {
-        return User.IsInRole("Admin") || User.IsInRole("Manager");
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
     }
 
     private async Task<Backend.Models.Entities.TaskItem> EnsureTaskAccessInProjectAsync(Guid projectId, Guid taskId)

--- a/Backend/Controllers/NotificationController.cs
+++ b/Backend/Controllers/NotificationController.cs
@@ -4,13 +4,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
-using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/notifications")]
 [Authorize]
-public class NotificationController : ControllerBase
+public class NotificationController : BaseApiController
 {
     private readonly INotificationService _notificationService;
 
@@ -149,11 +148,5 @@ public class NotificationController : ControllerBase
         {
             return StatusCode(500, ApiResponseDto<object>.Fail($"Internal server error: {ex.Message}"));
         }
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier);
-        return Guid.Parse(userIdClaim?.Value ?? throw new UnauthorizedAccessException("User ID not found in token"));
     }
 }

--- a/Backend/Controllers/ProfileController.cs
+++ b/Backend/Controllers/ProfileController.cs
@@ -1,6 +1,5 @@
 namespace Backend.Controllers;
 
-using System.Security.Claims;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -10,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/profile")]
 [Authorize]
-public class ProfileController : ControllerBase
+public class ProfileController : BaseApiController
 {
     private readonly IProfileService _profileService;
 
@@ -45,15 +44,5 @@ public class ProfileController : ControllerBase
     {
         await _profileService.DeleteAccountAsync(GetCurrentUserId(), dto);
         return Ok(ApiResponseDto<object>.Ok(null, "Account deleted"));
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
     }
 }

--- a/Backend/Controllers/ProjectController.cs
+++ b/Backend/Controllers/ProjectController.cs
@@ -4,13 +4,12 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
-using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/projects")]
 [Authorize]
-public class ProjectController : ControllerBase
+public class ProjectController : BaseApiController
 {
     private readonly IProjectService _service;
 
@@ -23,7 +22,7 @@ public class ProjectController : ControllerBase
     [Authorize(Policy = "ProjectRead")]
     public async Task<IActionResult> GetAll()
     {
-        var projects = await _service.GetAccessibleProjects(GetCurrentUserId(), HasElevatedAccess());
+        var projects = await _service.GetAccessibleProjects(GetCurrentUserId(), HasElevatedAccess(includeManager: false));
         return Ok(ApiResponseDto<List<Backend.Models.Entities.Project>>.Ok(projects, "Projects retrieved"));
     }
 
@@ -42,7 +41,7 @@ public class ProjectController : ControllerBase
         if (!await _service.ProjectExists(id))
             return NotFound(ApiResponseDto<object>.Fail("Project not found"));
 
-        var canRead = await _service.HasReadAccess(id, GetCurrentUserId(), HasElevatedAccess());
+        var canRead = await _service.HasReadAccess(id, GetCurrentUserId(), HasElevatedAccess(includeManager: false));
         if (!canRead)
             return Forbid();
 
@@ -60,7 +59,7 @@ public class ProjectController : ControllerBase
         if (!await _service.ProjectExists(id))
             return NotFound(ApiResponseDto<object>.Fail("Project not found"));
 
-        var canWrite = await _service.HasWriteAccess(id, GetCurrentUserId(), HasElevatedAccess());
+        var canWrite = await _service.HasWriteAccess(id, GetCurrentUserId(), HasElevatedAccess(includeManager: false));
         if (!canWrite)
             return Forbid();
 
@@ -78,7 +77,7 @@ public class ProjectController : ControllerBase
         if (!await _service.ProjectExists(id))
             return NotFound(ApiResponseDto<object>.Fail("Project not found"));
 
-        var canWrite = await _service.HasWriteAccess(id, GetCurrentUserId(), HasElevatedAccess());
+        var canWrite = await _service.HasWriteAccess(id, GetCurrentUserId(), HasElevatedAccess(includeManager: false));
         if (!canWrite)
             return Forbid();
 
@@ -96,7 +95,7 @@ public class ProjectController : ControllerBase
         if (!await _service.ProjectExists(id))
             return NotFound(ApiResponseDto<object>.Fail("Project not found"));
 
-        var canRead = await _service.HasReadAccess(id, GetCurrentUserId(), HasElevatedAccess());
+        var canRead = await _service.HasReadAccess(id, GetCurrentUserId(), HasElevatedAccess(includeManager: false));
         if (!canRead)
             return Forbid();
 
@@ -112,7 +111,7 @@ public class ProjectController : ControllerBase
             return NotFound(ApiResponseDto<object>.Fail("Project not found"));
 
         var currentUserId = GetCurrentUserId();
-        var canManage = await _service.HasManageAccess(id, currentUserId, HasElevatedAccess());
+        var canManage = await _service.HasManageAccess(id, currentUserId, HasElevatedAccess(includeManager: false));
         if (!canManage)
             return Forbid();
 
@@ -139,7 +138,7 @@ public class ProjectController : ControllerBase
             return NotFound(ApiResponseDto<object>.Fail("Project not found"));
 
         var currentUserId = GetCurrentUserId();
-        var canManage = await _service.HasManageAccess(id, currentUserId, HasElevatedAccess());
+        var canManage = await _service.HasManageAccess(id, currentUserId, HasElevatedAccess(includeManager: false));
         if (!canManage)
             return Forbid();
 
@@ -155,7 +154,7 @@ public class ProjectController : ControllerBase
             return NotFound(ApiResponseDto<object>.Fail("Project not found"));
 
         var currentUserId = GetCurrentUserId();
-        var canManage = await _service.HasManageAccess(id, currentUserId, HasElevatedAccess());
+        var canManage = await _service.HasManageAccess(id, currentUserId, HasElevatedAccess(includeManager: false));
         if (!canManage)
             return Forbid();
 
@@ -224,20 +223,5 @@ public class ProjectController : ControllerBase
         {
             return BadRequest(ApiResponseDto<object>.Fail(ex.Message));
         }
-    }
-
-    private bool HasElevatedAccess()
-    {
-        return User.IsInRole("Admin");
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
     }
 }

--- a/Backend/Controllers/SettingsController.cs
+++ b/Backend/Controllers/SettingsController.cs
@@ -1,6 +1,5 @@
 namespace Backend.Controllers;
 
-using System.Security.Claims;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -10,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/settings")]
 [Authorize]
-public class SettingsController : ControllerBase
+public class SettingsController : BaseApiController
 {
     private readonly ISettingsService _settingsService;
 
@@ -33,15 +32,5 @@ public class SettingsController : ControllerBase
         var userId = GetCurrentUserId();
         var settings = await _settingsService.UpdateCurrentUserSettingsAsync(userId, dto);
         return Ok(ApiResponseDto<UserSettingsDto>.Ok(settings, "Settings updated"));
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
     }
 }

--- a/Backend/Controllers/TaskAccessController.cs
+++ b/Backend/Controllers/TaskAccessController.cs
@@ -1,0 +1,61 @@
+namespace Backend.Controllers;
+
+using Backend.Services.Interfaces;
+
+/// <summary>
+/// Base controller for task-scoped endpoints that need read/write access checks.
+/// Provides EnsureTaskReadAccessAsync and EnsureTaskWriteAccessAsync, eliminating
+/// their duplication across TaskController, CommentController, ChecklistController,
+/// and TaskAttachmentController.
+/// </summary>
+public abstract class TaskAccessController : BaseApiController
+{
+    protected readonly ITaskService TaskService;
+    protected readonly IProjectService ProjectService;
+
+    protected TaskAccessController(ITaskService taskService, IProjectService projectService)
+    {
+        TaskService = taskService;
+        ProjectService = projectService;
+    }
+
+    /// <summary>
+    /// Ensures the current user has read access to the task's project.
+    /// Admins and Managers bypass the check.
+    /// </summary>
+    protected async Task<Backend.Models.Entities.TaskItem> EnsureTaskReadAccessAsync(Guid taskId)
+    {
+        var task = await TaskService.GetById(taskId);
+
+        if (HasElevatedAccess())
+            return task;
+
+        var currentUserId = GetCurrentUserId();
+        var canRead = await ProjectService.HasReadAccess(task.ProjectId, currentUserId, elevatedAccess: false);
+
+        if (!canRead)
+            throw new UnauthorizedAccessException("You do not have read access to this task");
+
+        return task;
+    }
+
+    /// <summary>
+    /// Ensures the current user has write access to the task's project.
+    /// Admins and Managers bypass the check.
+    /// </summary>
+    protected async Task<Backend.Models.Entities.TaskItem> EnsureTaskWriteAccessAsync(Guid taskId)
+    {
+        var task = await TaskService.GetById(taskId);
+
+        if (HasElevatedAccess())
+            return task;
+
+        var currentUserId = GetCurrentUserId();
+        var canWrite = await ProjectService.HasWriteAccess(task.ProjectId, currentUserId, elevatedAccess: false);
+
+        if (!canWrite)
+            throw new UnauthorizedAccessException("You do not have write access to this task");
+
+        return task;
+    }
+}

--- a/Backend/Controllers/TaskAttachmentController.cs
+++ b/Backend/Controllers/TaskAttachmentController.cs
@@ -5,36 +5,26 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
-using System.Security.Claims;
 using Microsoft.AspNetCore.StaticFiles;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/tasks/{taskId}/attachments")]
 [Authorize]
-public class TaskAttachmentController : ControllerBase
+public class TaskAttachmentController : TaskAccessController
 {
     private readonly ITaskAttachmentService _attachmentService;
-    private readonly ITaskService _taskService;
-    private readonly IProjectService? _projectService;
     private readonly IWebHostEnvironment? _hostEnvironment;
     private const long MaxUploadFileSizeBytes = 10 * 1024 * 1024;
 
-    public TaskAttachmentController(ITaskAttachmentService attachmentService, ITaskService taskService)
-        : this(attachmentService, taskService, null, null)
-    {
-    }
-
-    [ActivatorUtilitiesConstructor]
     public TaskAttachmentController(
         ITaskAttachmentService attachmentService,
         ITaskService taskService,
-        IProjectService? projectService,
-        IWebHostEnvironment? hostEnvironment)
+        IProjectService projectService,
+        IWebHostEnvironment? hostEnvironment = null)
+        : base(taskService, projectService)
     {
         _attachmentService = attachmentService;
-        _taskService = taskService;
-        _projectService = projectService;
         _hostEnvironment = hostEnvironment;
     }
 
@@ -265,21 +255,6 @@ public class TaskAttachmentController : ControllerBase
         }
     }
 
-    private bool HasElevatedAccess()
-    {
-        return User.IsInRole("Admin") || User.IsInRole("Manager");
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
-    }
-
     private string GetTaskAttachmentDirectoryPath(Guid taskId)
     {
         var basePath = _hostEnvironment?.ContentRootPath ?? Directory.GetCurrentDirectory();
@@ -315,55 +290,5 @@ public class TaskAttachmentController : ControllerBase
         {
             // Physical file cleanup should not fail the API flow.
         }
-    }
-
-    private async Task<Backend.Models.Entities.TaskItem> EnsureTaskReadAccessAsync(Guid taskId)
-    {
-        var task = await _taskService.GetById(taskId);
-
-        if (HasElevatedAccess())
-            return task;
-
-        var currentUserId = GetCurrentUserId();
-
-        if (_projectService != null)
-        {
-            var canRead = await _projectService.HasReadAccess(task.ProjectId, currentUserId, elevatedAccess: false);
-
-            if (!canRead)
-                throw new UnauthorizedAccessException("You do not have read access to this task");
-
-            return task;
-        }
-
-        if (task.AssignedUserId != currentUserId)
-            throw new UnauthorizedAccessException("You can only access your own tasks");
-
-        return task;
-    }
-
-    private async Task<Backend.Models.Entities.TaskItem> EnsureTaskWriteAccessAsync(Guid taskId)
-    {
-        var task = await _taskService.GetById(taskId);
-
-        if (HasElevatedAccess())
-            return task;
-
-        var currentUserId = GetCurrentUserId();
-
-        if (_projectService != null)
-        {
-            var canWrite = await _projectService.HasWriteAccess(task.ProjectId, currentUserId, elevatedAccess: false);
-
-            if (!canWrite)
-                throw new UnauthorizedAccessException("You do not have write access to this task");
-
-            return task;
-        }
-
-        if (task.AssignedUserId != currentUserId)
-            throw new UnauthorizedAccessException("You can only access your own tasks");
-
-        return task;
     }
 }

--- a/Backend/Controllers/TaskController.cs
+++ b/Backend/Controllers/TaskController.cs
@@ -5,21 +5,19 @@ using Microsoft.AspNetCore.Mvc;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
 using Backend.Models.Entities;
-using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/tasks")]
 [Authorize]
-public class TaskController : ControllerBase
+public class TaskController : TaskAccessController
 {
     private readonly ITaskService _service;
-    private readonly IProjectService _projectService;
 
     public TaskController(ITaskService service, IProjectService projectService)
+        : base(service, projectService)
     {
         _service = service;
-        _projectService = projectService;
     }
 
     [HttpPost]
@@ -28,10 +26,10 @@ public class TaskController : ControllerBase
     {
         var currentUserId = GetCurrentUserId();
 
-        if (!await _projectService.ProjectExists(dto.ProjectId))
+        if (!await ProjectService.ProjectExists(dto.ProjectId))
             return NotFound(ApiResponseDto<object>.Fail("Project not found"));
 
-        var canWrite = await _projectService.HasWriteAccess(dto.ProjectId, currentUserId, HasElevatedAccess());
+        var canWrite = await ProjectService.HasWriteAccess(dto.ProjectId, currentUserId, HasElevatedAccess());
         if (!canWrite)
             return Forbid();
 
@@ -54,7 +52,7 @@ public class TaskController : ControllerBase
         if (!HasElevatedAccess())
         {
             var currentUserId = GetCurrentUserId();
-            var accessibleProjects = await _projectService.GetAccessibleProjects(currentUserId, elevatedAccess: false);
+            var accessibleProjects = await ProjectService.GetAccessibleProjects(currentUserId, elevatedAccess: false);
             projectIds = accessibleProjects.Select(project => project.Id).ToList();
         }
 
@@ -138,52 +136,5 @@ public class TaskController : ControllerBase
         await EnsureTaskWriteAccessAsync(id);
         var item = await _service.UpdateChecklistItemCompletion(id, checklistItemId, dto.IsCompleted ?? false);
         return Ok(ApiResponseDto<ChecklistItem>.Ok(item, "Checklist item updated"));
-    }
-
-    private bool HasElevatedAccess()
-    {
-        return User.IsInRole("Admin") || User.IsInRole("Manager");
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
-    }
-
-    private async Task<TaskItem> EnsureTaskReadAccessAsync(Guid taskId)
-    {
-        var task = await _service.GetById(taskId);
-
-        if (HasElevatedAccess())
-            return task;
-
-        var currentUserId = GetCurrentUserId();
-        var canRead = await _projectService.HasReadAccess(task.ProjectId, currentUserId, elevatedAccess: false);
-
-        if (!canRead)
-            throw new UnauthorizedAccessException("You do not have read access to this task");
-
-        return task;
-    }
-
-    private async Task<TaskItem> EnsureTaskWriteAccessAsync(Guid taskId)
-    {
-        var task = await _service.GetById(taskId);
-
-        if (HasElevatedAccess())
-            return task;
-
-        var currentUserId = GetCurrentUserId();
-        var canWrite = await _projectService.HasWriteAccess(task.ProjectId, currentUserId, elevatedAccess: false);
-
-        if (!canWrite)
-            throw new UnauthorizedAccessException("You do not have write access to this task");
-
-        return task;
     }
 }

--- a/Backend/Controllers/TaskWatcherController.cs
+++ b/Backend/Controllers/TaskWatcherController.cs
@@ -4,13 +4,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
-using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/tasks/{taskId}/watchers")]
 [Authorize]
-public class TaskWatcherController : ControllerBase
+public class TaskWatcherController : BaseApiController
 {
     private readonly ITaskWatcherService _watcherService;
     private readonly ITaskService _taskService;
@@ -207,21 +206,6 @@ public class TaskWatcherController : ControllerBase
         {
             return StatusCode(500, ApiResponseDto<object>.Fail($"Internal server error: {ex.Message}"));
         }
-    }
-
-    private bool HasElevatedAccess()
-    {
-        return User.IsInRole("Admin") || User.IsInRole("Manager");
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
     }
 
     private async Task<Backend.Models.Entities.TaskItem> EnsureTaskAccessAsync(Guid taskId)

--- a/Backend/Controllers/UserController.cs
+++ b/Backend/Controllers/UserController.cs
@@ -4,13 +4,12 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Backend.Models.DTOs;
 using Backend.Services.Interfaces;
-using System.Security.Claims;
 
 [ApiController]
 [Asp.Versioning.ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}/users")]
 [Authorize]
-public class UserController : ControllerBase
+public class UserController : BaseApiController
 {
     private readonly IUserService _service;
 
@@ -36,20 +35,5 @@ public class UserController : ControllerBase
 
         var user = await _service.GetById(id);
         return Ok(ApiResponseDto<UserDto>.Ok(user, "User retrieved"));
-    }
-
-    private bool HasElevatedAccess()
-    {
-        return User.IsInRole("Admin") || User.IsInRole("Manager");
-    }
-
-    private Guid GetCurrentUserId()
-    {
-        var userIdClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-
-        if (!Guid.TryParse(userIdClaim, out var userId))
-            throw new UnauthorizedAccessException("Invalid user context");
-
-        return userId;
     }
 }

--- a/Backend/Data/AppDbContext.cs
+++ b/Backend/Data/AppDbContext.cs
@@ -19,6 +19,7 @@ public class AppDbContext : DbContext
     public DbSet<TaskAttachment> Attachments { get; set; }
     public DbSet<TaskWatcher> TaskWatchers { get; set; }
     public DbSet<Notification> Notifications { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -161,6 +162,23 @@ public class AppDbContext : DbContext
             .WithMany()
             .HasForeignKey(tw => tw.UserId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        // RefreshToken Configuration
+        modelBuilder.Entity<RefreshToken>()
+            .HasIndex(rt => rt.Token)
+            .IsUnique();
+
+        modelBuilder.Entity<RefreshToken>()
+            .HasOne(rt => rt.User)
+            .WithMany()
+            .HasForeignKey(rt => rt.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        modelBuilder.Entity<RefreshToken>()
+            .HasOne(rt => rt.ReplacedByToken)
+            .WithMany()
+            .HasForeignKey(rt => rt.ReplacedByTokenId)
+            .OnDelete(DeleteBehavior.SetNull);
 
         // Notification Configuration
         modelBuilder.Entity<Notification>().HasQueryFilter(n => !n.IsDeleted);

--- a/Backend/Data/JwtSettingsOptions.cs
+++ b/Backend/Data/JwtSettingsOptions.cs
@@ -9,7 +9,8 @@ public class JwtSettingsOptions
     public string Secret { get; set; } = string.Empty;
     public string Issuer { get; set; } = string.Empty;
     public string Audience { get; set; } = string.Empty;
-    public int ExpirationHours { get; set; } = 24;
+    public int AccessTokenExpirationMinutes { get; set; } = 15;
+    public int RefreshTokenExpirationDays { get; set; } = 7;
 
     public IEnumerable<string> Validate()
     {
@@ -24,7 +25,10 @@ public class JwtSettingsOptions
         if (string.IsNullOrWhiteSpace(Audience))
             yield return $"{SectionName}:Audience is required";
 
-        if (ExpirationHours <= 0)
-            yield return $"{SectionName}:ExpirationHours must be greater than 0";
+        if (AccessTokenExpirationMinutes <= 0)
+            yield return $"{SectionName}:AccessTokenExpirationMinutes must be greater than 0";
+
+        if (RefreshTokenExpirationDays <= 0)
+            yield return $"{SectionName}:RefreshTokenExpirationDays must be greater than 0";
     }
 }

--- a/Backend/Extensions/DatabaseExtensions.cs
+++ b/Backend/Extensions/DatabaseExtensions.cs
@@ -1,20 +1,6 @@
 using Backend.Data;
-using Backend.Middleware;
-using Backend.Services.Interfaces;
-using Backend.Services.Implementations;
-using Backend.Models.DTOs;
-using Backend.Validation;
-using FluentValidation;
-using FluentValidation.AspNetCore;
-using Microsoft.IdentityModel.Tokens;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.OpenApi.Models;
-using System.Text;
-using AspNetCoreRateLimit;
-using Microsoft.Extensions.Options;
-using Asp.Versioning;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using Npgsql;
 
 namespace Backend.Extensions;

--- a/Backend/Models/DTOs/AuthResponseDto.cs
+++ b/Backend/Models/DTOs/AuthResponseDto.cs
@@ -5,6 +5,8 @@ public class AuthResponseDto
     public bool Success { get; set; }
     public string Message { get; set; } = string.Empty;
     public string? Token { get; set; }
+    public string? RefreshToken { get; set; }
+    public DateTime? RefreshTokenExpiry { get; set; }
     public UserDto? User { get; set; }
 }
 

--- a/Backend/Models/DTOs/RefreshTokenDto.cs
+++ b/Backend/Models/DTOs/RefreshTokenDto.cs
@@ -1,0 +1,6 @@
+namespace Backend.Models.DTOs;
+
+public class RefreshTokenDto
+{
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/Backend/Models/Entities/RefreshToken.cs
+++ b/Backend/Models/Entities/RefreshToken.cs
@@ -1,0 +1,31 @@
+namespace Backend.Models.Entities;
+
+public class RefreshToken
+{
+    public Guid Id { get; set; }
+
+    public string Token { get; set; } = string.Empty;
+
+    public Guid UserId { get; set; }
+
+    public User User { get; set; } = null!;
+
+    public DateTime ExpiresAt { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime? RevokedAt { get; set; }
+
+    /// <summary>
+    /// When this token is rotated, points to the replacement token for audit trail.
+    /// </summary>
+    public Guid? ReplacedByTokenId { get; set; }
+
+    public RefreshToken? ReplacedByToken { get; set; }
+
+    public bool IsRevoked => RevokedAt != null;
+
+    public bool IsExpired => DateTime.UtcNow >= ExpiresAt;
+
+    public bool IsActive => !IsRevoked && !IsExpired;
+}

--- a/Backend/Services/Implementations/AuthService.cs
+++ b/Backend/Services/Implementations/AuthService.cs
@@ -1,16 +1,17 @@
 namespace Backend.Services.Implementations;
 
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using BCrypt.Net;
-using Backend.Models.DTOs;
 using Backend.Data;
+using Backend.Models.DTOs;
 using Backend.Models.Entities;
 using Backend.Services.Interfaces;
 using Microsoft.EntityFrameworkCore;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 
 public class AuthService : IAuthService
 {
@@ -51,10 +52,16 @@ public class AuthService : IAuthService
         _context.Users.Add(user);
         await _context.SaveChangesAsync();
 
+        var accessToken = GenerateJwtToken(user);
+        var refreshToken = await CreateRefreshTokenAsync(user.Id);
+
         return new AuthResponseDto
         {
             Success = true,
             Message = "User registered successfully",
+            Token = accessToken,
+            RefreshToken = refreshToken.Token,
+            RefreshTokenExpiry = refreshToken.ExpiresAt,
             User = new UserDto
             {
                 Id = user.Id,
@@ -80,13 +87,16 @@ public class AuthService : IAuthService
             };
         }
 
-        var token = GenerateJwtToken(user);
+        var accessToken = GenerateJwtToken(user);
+        var refreshToken = await CreateRefreshTokenAsync(user.Id);
 
         return new AuthResponseDto
         {
             Success = true,
             Message = "Login successful",
-            Token = token,
+            Token = accessToken,
+            RefreshToken = refreshToken.Token,
+            RefreshTokenExpiry = refreshToken.ExpiresAt,
             User = new UserDto
             {
                 Id = user.Id,
@@ -94,6 +104,121 @@ public class AuthService : IAuthService
                 Email = user.Email
             }
         };
+    }
+
+    public async Task<AuthResponseDto> RefreshTokenAsync(string refreshToken)
+    {
+        var storedToken = await _context.RefreshTokens
+            .Include(rt => rt.User)
+            .FirstOrDefaultAsync(rt => rt.Token == refreshToken);
+
+        if (storedToken == null)
+        {
+            return new AuthResponseDto
+            {
+                Success = false,
+                Message = "Invalid refresh token"
+            };
+        }
+
+        if (storedToken.IsRevoked)
+        {
+            // Possible token reuse detected — revoke the entire family
+            _logger.LogWarning(
+                "Revoked refresh token reuse detected for UserId={UserId}, Token={TokenPrefix}...",
+                storedToken.UserId,
+                storedToken.Token[..8]);
+
+            await RevokeAllTokensAsync(storedToken.UserId);
+
+            return new AuthResponseDto
+            {
+                Success = false,
+                Message = "Token has been revoked. All sessions have been invalidated for security."
+            };
+        }
+
+        if (storedToken.IsExpired)
+        {
+            return new AuthResponseDto
+            {
+                Success = false,
+                Message = "Refresh token has expired"
+            };
+        }
+
+        if (storedToken.User.IsDeleted)
+        {
+            return new AuthResponseDto
+            {
+                Success = false,
+                Message = "User account has been deleted"
+            };
+        }
+
+        // Rotate: revoke old token and create new one
+        storedToken.RevokedAt = DateTime.UtcNow;
+        var newRefreshToken = await CreateRefreshTokenAsync(storedToken.UserId);
+
+        storedToken.ReplacedByTokenId = newRefreshToken.Id;
+        await _context.SaveChangesAsync();
+
+        var accessToken = GenerateJwtToken(storedToken.User);
+
+        _logger.LogInformation(
+            "Rotated refresh token for UserId={UserId}",
+            storedToken.UserId);
+
+        return new AuthResponseDto
+        {
+            Success = true,
+            Message = "Token refreshed successfully",
+            Token = accessToken,
+            RefreshToken = newRefreshToken.Token,
+            RefreshTokenExpiry = newRefreshToken.ExpiresAt,
+            User = new UserDto
+            {
+                Id = storedToken.User.Id,
+                Name = storedToken.User.Name,
+                Email = storedToken.User.Email
+            }
+        };
+    }
+
+    public async Task LogoutAsync(string refreshToken)
+    {
+        var storedToken = await _context.RefreshTokens
+            .FirstOrDefaultAsync(rt => rt.Token == refreshToken);
+
+        if (storedToken == null || storedToken.IsRevoked)
+            return; // Idempotent — no error for already-revoked or missing tokens
+
+        storedToken.RevokedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Revoked refresh token for UserId={UserId} (logout)",
+            storedToken.UserId);
+    }
+
+    public async Task RevokeAllTokensAsync(Guid userId)
+    {
+        var activeTokens = await _context.RefreshTokens
+            .Where(rt => rt.UserId == userId && rt.RevokedAt == null)
+            .ToListAsync();
+
+        var now = DateTime.UtcNow;
+        foreach (var token in activeTokens)
+        {
+            token.RevokedAt = now;
+        }
+
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation(
+            "Revoked {Count} active refresh token(s) for UserId={UserId}",
+            activeTokens.Count,
+            userId);
     }
 
     private string GenerateJwtToken(User user)
@@ -113,18 +238,40 @@ public class AuthService : IAuthService
             issuer: _jwtSettings.Issuer,
             audience: _jwtSettings.Audience,
             claims: claims,
-            expires: DateTime.UtcNow.AddHours(_jwtSettings.ExpirationHours),
+            expires: DateTime.UtcNow.AddMinutes(_jwtSettings.AccessTokenExpirationMinutes),
             signingCredentials: credentials
         );
 
         _logger.LogInformation(
-            "Generated JWT token for UserId={UserId} with issuer={Issuer}, audience={Audience}, expirationHours={ExpirationHours}",
+            "Generated JWT token for UserId={UserId} with issuer={Issuer}, audience={Audience}, expirationMinutes={ExpirationMinutes}",
             user.Id,
             _jwtSettings.Issuer,
             _jwtSettings.Audience,
-            _jwtSettings.ExpirationHours);
+            _jwtSettings.AccessTokenExpirationMinutes);
 
         return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    private async Task<RefreshToken> CreateRefreshTokenAsync(Guid userId)
+    {
+        var refreshToken = new RefreshToken
+        {
+            Token = GenerateRefreshTokenString(),
+            UserId = userId,
+            ExpiresAt = DateTime.UtcNow.AddDays(_jwtSettings.RefreshTokenExpirationDays),
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _context.RefreshTokens.Add(refreshToken);
+        await _context.SaveChangesAsync();
+
+        return refreshToken;
+    }
+
+    private static string GenerateRefreshTokenString()
+    {
+        var randomBytes = RandomNumberGenerator.GetBytes(64);
+        return Convert.ToBase64String(randomBytes);
     }
 
     private static string NormalizeEmail(string email)

--- a/Backend/Services/Interfaces/IAuthService.cs
+++ b/Backend/Services/Interfaces/IAuthService.cs
@@ -7,4 +7,7 @@ public interface IAuthService
 {
     Task<AuthResponseDto> Register(RegisterDto dto);
     Task<AuthResponseDto> Login(LoginDto dto);
+    Task<AuthResponseDto> RefreshTokenAsync(string refreshToken);
+    Task LogoutAsync(string refreshToken);
+    Task RevokeAllTokensAsync(Guid userId);
 }

--- a/Backend/appsettings.json
+++ b/Backend/appsettings.json
@@ -21,7 +21,8 @@
   "JwtSettings": {
     "Issuer": "GDG-TaskFlow",
     "Audience": "GDG-TaskFlow-Users",
-    "ExpirationHours": 24,
+    "AccessTokenExpirationMinutes": 15,
+    "RefreshTokenExpirationDays": 7,
     "Secret": "super-secret-key-that-should-be-replaced-in-production"
   },
   "Redis": {


### PR DESCRIPTION
What was implemented:
Refresh Token System:

Secure rotating refresh tokens with reuse detection
Access tokens reduced to 15 min (from 24 hours), refresh tokens last 7 days
3 new endpoints: /auth/refresh, /auth/logout, /auth/revoke-all
If a revoked token is reused, all user sessions are automatically invalidated
Backend Refactoring:

Created BaseApiController and TaskAccessController base classes
Eliminated ~30+ duplicate method copies across 13 controllers
Cleaned up 14 stale using directives in DatabaseExtensions.cs
Simplified CommentController and TaskAttachmentController constructors